### PR TITLE
Convert to next-auth package + change next peerDependency version to …

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,16 +26,6 @@
     "oidc",
     "nextauth"
   ],
-  "exports": {
-    ".": "./index.js",
-    "./jwt": "./jwt/index.js",
-    "./react": "./react/index.js",
-    "./core": "./core/index.js",
-    "./next": "./next/index.js",
-    "./middleware": "./middleware.js",
-    "./client/_utils": "./client/_utils.js",
-    "./providers/*": "./providers/*.js"
-  },
   "files": [
     "lib",
     "css",


### PR DESCRIPTION
Remove the exports field since its sort of broken, and we need to update anyway. 